### PR TITLE
Pull in and start After=network-online.target

### DIFF
--- a/config/eturnal.service
+++ b/config/eturnal.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=eturnal STUN/TURN server
-Wants=epmd.service
-After=epmd.service network.target
+Wants=epmd.service network-online.target
+After=epmd.service network-online.target
 Documentation=https://eturnal.net/documentation/
 Documentation=https://github.com/processone/eturnal/blob/{{release_version}}/README.md
 Documentation=https://github.com/processone/eturnal/blob/{{release_version}}/CHANGELOG.md


### PR DESCRIPTION
network.target has very little meaning, usually network interfaces are being configured (not yet finished) when it is reached: https://www.freedesktop.org/software/systemd/man/systemd.special.html#network.target

Instead, network-online.target is intended to be reached after all network interfaces have been fully configured. Since it is an active target, it needs to be pulled in: https://www.freedesktop.org/software/systemd/man/systemd.special.html#network-online.target