### PR TITLE
Add a macos CI as well as a homebrew formula

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     paths-ignore:
       - '*.md'
       - 'docker-k8s/**'
+      - 'Formula/**'
   pull_request:
     paths-ignore:
       - '*.md'
       - 'docker-k8s/**'
+      - 'Formula/**'
 
 jobs:
   test:

--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'doc/**'
       - 'docker-k8s/examples/**'
+      - 'Formula/**'
       - 'scripts/get-version'
       - 'windows/**'
       - '**.md'
@@ -16,6 +17,7 @@ on:
     paths-ignore:
       - 'doc/**'
       - 'docker-k8s/examples/**'
+      - 'Formula/**'
       - 'scripts/get-version'
       - 'windows/**'
       - '**.md'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,12 +15,10 @@ on:
       - 'windows/**'
 
 jobs:
-  installer:
-    name: macOS-${{ matrix.macos_vsn }} with homebrew
-    runs-on: macos-${{ matrix.macos_vsn }}
-    strategy:
-      matrix:
-        macos_vsn: [11, 12, 13]
+
+  ci:
+    name: CI | macOS with homebrew
+    runs-on: macos-latest
 
     steps:
       - name: Check out repository code
@@ -28,6 +26,10 @@ jobs:
         with: # For scripts/get-version:
           fetch-depth: 0
       - name: Install dependencies
+        env:
+            HOMEBREW_NO_AUTO_UPDATE: 1
+            HOMEBREW_NO_INSTALL_CLEANUP: 1
+            HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
             brew update
             brew install \
@@ -70,3 +72,64 @@ jobs:
         run: rebar3 eunit
       - name: Check test coverage
         run: rebar3 cover
+
+  formula:
+    name: On ${{ matrix.os }} | install & test ${{ matrix.vsn }} Formula
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [macos, ubuntu]
+        vsn: [head, stable]
+      fail-fast: false
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v3
+        with:
+            path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+            key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+            restore-keys: ${{ runner.os }}-rubygems-
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
+
+      - name: Install eturnal with homebrew formula
+        env:
+            HOMEBREW_NO_AUTO_UPDATE: 1
+            HOMEBREW_NO_INSTALL_CLEANUP: 1
+            HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        run: |
+            if [ ${{ matrix.vsn }} = 'head' ]; then export vsn='--head'; fi
+            # Download eturnal.rb instead of `brew tap` to avoid failures when
+            # running on branches or pull requests -> requires actions/checkout
+            curl -O https://raw.githubusercontent.com/${{ github.repository }}/$(git rev-parse HEAD)/Formula/eturnal.rb
+            brew install --build-from-source ${vsn:-} --verbose ./eturnal.rb
+      - name: Homebrew autoremove unused packages
+        if: matrix.os != 'ubuntu'
+        run: |
+            brew uninstall erlang rebar3
+            brew autoremove
+      - name: Set erlang cookie, because we build from HEAD
+        if: matrix.vsn == 'head'
+        run: echo "-setcookie eturnal" >> $(find $(brew --prefix)/Cellar/eturnal -name vm.args)
+      - name: Run eturnal Formula test
+        run: brew test --verbose eturnal
+      - name: Start eturnal service
+        run: brew services start eturnal
+      - name: Wait shortly
+        run: sleep 10
+      - name: Create test credentials
+        run: $(brew --prefix)/opt/eturnal/bin/eturnalctl credentials
+      - name: Test eturnalctl on $PATH
+        run: eturnalctl info
+      - name: Stop eturnal service
+        run: brew services stop eturnal
+ #     - name: Lint formula
+ #       run: brew audit --strict eturnal
+

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -130,6 +130,9 @@ jobs:
         run: eturnalctl info
       - name: Stop eturnal service
         run: brew services stop eturnal
- #     - name: Lint formula
- #       run: brew audit --strict eturnal
+      - name: Lint formula
+        ## we know, it fails due to non-executables in the /bin directory, but
+        ## we want to see if anything else needs further investigation
+        continue-on-error: true
+        run: brew audit --strict eturnal
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,72 @@
+name: CI | macOS
+
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'doc/**'
+      - 'docker-k8s/**'
+      - 'windows/**'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'doc/**'
+      - 'docker-k8s/**'
+      - 'windows/**'
+
+jobs:
+  installer:
+    name: macOS-${{ matrix.macos_vsn }} with homebrew
+    runs-on: macos-${{ matrix.macos_vsn }}
+    strategy:
+      matrix:
+        macos_vsn: [11, 12, 13]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with: # For scripts/get-version:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+            brew update
+            brew install \
+                erlang \
+                openssl \
+                libyaml \
+                rebar3
+      - name: Cache Rebar data
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/rebar3
+          key: ${{ runner.os }}-${{ hashFiles('rebar.config') }}
+      # Until https://github.com/erlware/relx/issues/905 is fixed:
+      - name: Create Erlang cookie
+        run: erl -noinput -sname cookie -eval 'halt()'
+      - name: Download dependencies
+        run: rebar3 get-deps
+      - name: Compile code
+        env:
+            LDFLAGS: -L/usr/local/opt/openssl/lib -L/usr/local/lib
+            CFLAGS: -I/usr/local/opt/openssl/include/ -I/usr/local/include
+            CPPFLAGS: -I/usr/local/opt/openssl/include/ -I/usr/local/include
+        run: rebar3 compile
+      - name: Build release
+        run: rebar3 release
+      - name: Start release
+        run: _build/default/rel/eturnal/bin/eturnal daemon
+      - name: Ping release
+        run: _build/default/rel/eturnal/bin/eturnal ping
+      - name: Stop release
+        run: _build/default/rel/eturnal/bin/eturnal stop
+      - name: Analyze cross references
+        run: rebar3 xref
+      - name: Perform static code analysis
+        run: rebar3 dialyzer
+      - name: Run black-box tests (CT)
+        run: rebar3 ct || rebar3 ct
+        shell: bash
+      - name: Run white-box tests (EUnit)
+        run: rebar3 eunit
+      - name: Check test coverage
+        run: rebar3 cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ project adheres to [Semantic Versioning][SemVer].
 - Docker: Container images can now be pulled from Dockerhub as well. The name
   is `docker.io/eturnal/eturnal:latest`. When pulling with `Docker`, `docker.io`
   may be omitted.
+- Provide a [homebrew](https://brew.sh/) [Formula](https://github.com/processone/eturnal/blob/master/Formula/eturnal.rb)
+  for macOS.
 
 ### Changed
 - `mod_stats_prometheus`: Fine tune bucket sizes for TURN sessions, e.g., drop

--- a/Formula/eturnal.rb
+++ b/Formula/eturnal.rb
@@ -23,7 +23,6 @@ class Eturnal < Formula
     ## change default install dir, epmd address
     inreplace "build.config" do |s|
       s.gsub! "/opt/#{name}", opt_prefix.to_s
-      s.gsub! 'erl_epmd_address, "127.0.0.1"', 'erl_epmd_address, ""'
     end
     ## change default default config dir
     inreplace "config/sys.config" do |s|

--- a/Formula/eturnal.rb
+++ b/Formula/eturnal.rb
@@ -1,0 +1,118 @@
+class Eturnal < Formula
+  desc "STUN/TURN server"
+  homepage "https://eturnal.net"
+  url "https://eturnal.net/download/eturnal-1.10.1.tar.gz"
+  sha256 "a8f999a2a4b84cbe690bc762bb6b6bd67ebc70becb2f68c65b92e15edf132524"
+  license "Apache-2.0"
+  head "https://github.com/processone/eturnal.git", branch: "master"
+
+  depends_on "erlang" => :build
+  depends_on "rebar3" => :build
+  depends_on "libyaml"
+  depends_on "openssl@3"
+
+  on_linux do
+    depends_on "ncurses"
+    depends_on "zlib"
+  end
+
+  conflicts_with "ejabberd", because: "both install e.g. `p1_utils-x.x.x` lib"
+
+  def install
+    # Patches
+    ## change default install dir, epmd address
+    inreplace "build.config" do |s|
+      s.gsub! "/opt/#{name}", opt_prefix.to_s
+      s.gsub! 'erl_epmd_address, "127.0.0.1"', 'erl_epmd_address, ""'
+    end
+    ## change default default config dir
+    inreplace "config/sys.config" do |s|
+      s.gsub! "$ETURNAL_ETC_PREFIX/etc/#{name}.yml", "#{etc}/#{name}.yml"
+    end
+    ## !!! patch eturnalctl script, !!!
+    ## !!! remove before updating to newer version than 1.10.1 !!!
+    unless build.head?
+      inreplace "scripts/eturnalctl" do |s|
+        s.gsub! "(readlink ", "(readlink -f "
+      end
+    end
+
+    # build release
+    system "rebar3", "as", "prod", "release"
+    # conduct rebar3 test suites
+    system "rebar3", "xref"
+    system "rebar3", "eunit"
+    system "rebar3", "ct"
+
+    # install libraries & configuration files
+    prefix.install "_build/prod/rel/#{name}/bin"
+    prefix.install "_build/prod/rel/#{name}/lib"
+    prefix.install "_build/prod/rel/#{name}/releases"
+    prefix.install Dir["_build/prod/rel/#{name}/erts-*"]
+
+    cd "_build/prod/rel/#{name}/etc" do
+      etc.install "#{name}.yml"
+      (prefix/"etc").install "systemd"
+    end
+
+    # move doc pages
+    (share/"doc/#{name}").install "_build/prod/rel/#{name}/doc/LICENSE.txt"
+    (share/"doc/#{name}").install "_build/prod/rel/#{name}/doc/README.md"
+    (share/"doc/#{name}").install "_build/prod/rel/#{name}/doc/CHANGELOG.md"
+  end
+
+  def post_install
+    (var/"log/#{name}").mkpath
+    (var/"log/#{name}").install_symlink opt_prefix/"log"
+    (var/"run/#{name}").mkpath
+    (var/"run/#{name}").install_symlink opt_prefix/"run"
+    (var/"lib/#{name}").mkpath
+
+    # put a random secure cookie
+    # cannot use this with HEAD currently
+    unless build.head?
+      vm_args_file = opt_prefix/"releases/#{version}/vm.args"
+      require "securerandom"
+      cookie = SecureRandom.hex
+      File.open(vm_args_file.to_s, "a") { |f| f << "-setcookie #{cookie}\n" }
+    end
+  end
+
+  def caveats
+    <<~EOS
+      For convenience the erlang cookie is currently randomly hard-coded in
+      `$(brew --prefix)/opt/#{name}/releases/#{version}/vm.args`. To harden your
+      #{name} you should delete the last line '-setcookie r4nd0mstr1n6' and
+      afterwards start your service. Make sure, that all users calling #{name}
+      e.g. with $(brew --prefix)/opt/#{name}/bin/#{name}ctl have the same
+      `.erlang.cookie` file in their `$HOME` directory. This does currently not
+      apply to installations from HEAD.
+
+      With macOS > 12.3 `#{name}ctl` can be invoked directly without specifying
+      the path `$(brew --prefix)/opt/#{name}/bin/#{name}ctl`.
+
+      #{name}'s configuration file `$(brew --prefix)/etc/#{name}.yml` uses the
+      (indentation-sensitive!) YAML format. A documentation can be found on
+      https://#{name}.net or on https://github.com/processone/#{name}.
+    EOS
+  end
+
+  service do
+    run [opt_bin/"eturnalctl", "foreground"]
+    environment_variables HOME: var/"lib/eturnal"
+    working_dir var/"lib/eturnal"
+    # log_path var/"log/eturnal"
+    # error_log_path var/"log/eturnal"
+    # process_type :background
+  end
+
+  test do
+    ENV["HOME"] = var/"lib/eturnal"
+    ENV["LOGS_DIRECTORY"] = var/"log/eturnal"
+    ENV["RUNTIME_DIRECTORY"] = var/"run/eturnal"
+    system opt_prefix/"bin/#{name}ctl", "daemon"
+    system opt_prefix/"bin/#{name}ctl", "ping"
+    system opt_prefix/"bin/#{name}ctl", "info"
+    system opt_prefix/"bin/#{name}ctl", "stop"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -37,8 +37,14 @@ On **YUM-based** Linux distributions, run:
 On SUSE Linux Enterprise and openSUSE systems, [distribution repositories][7]
 can be used instead. There's also an official [Alpine package][8]. On other
 Linux systems, the binary release can be installed as [described][9] in the
-reference documentation. For Windows, an installer is [available][10]. On other
-platforms, eturnal is [built from source][11].
+reference documentation. For Windows, an installer is [available][10].
+
+On **macOS** using homebrew's
+
+    brew tap processone/eturnal https://github.com/processone/eturnal
+    brew install processone/eturnal/eturnal
+
+On other platforms, eturnal is [built from source][11].
 
 ## Configuration
 


### PR DESCRIPTION
We should wait  before merging if any more feedback from the homebrew team requires changes in `Formula/eturnal.rb`

Update: PR (https://github.com/Homebrew/homebrew-core/pull/133233), because the Formula does not pass the linting which 
> [...] we can hardly fix, because it is hard-coded in [relx-tools](https://github.com/erlware/relx).