### PR TITLE
ctr-actions: add a registry cleanup workflow

### DIFF
--- a/.github/workflows/container-cleanup-registry.yml
+++ b/.github/workflows/container-cleanup-registry.yml
@@ -1,0 +1,42 @@
+name: 'Docker: Delete all containers from package without tags'
+
+on:
+  schedule:
+    - cron: '44 4 * * *'
+
+jobs:
+  build:
+    name: Delete all containers from package without tags
+    runs-on: "ubuntu-latest"
+    steps:
+
+      - name: Check github repository owner type
+        run: |
+          if [ "${{ github.repository_owner }}" = 'processone' ]
+          then echo "OWNER_TYPE=org" >> $GITHUB_ENV
+          else echo "OWNER_TYPE=user" >> $GITHUB_ENV
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry with PAT_TOKEN
+        uses: docker/login-action@v2
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.PAT_TOKEN }}
+
+      - name: Delete all containers from package without tags
+ #       uses: Chizkiyahu/delete-untagged-ghcr-action@v2
+        ## This is a patched version from the action, which identifies manifests
+        ## created with 'buildkit' correctly. PR should be merged soon.
+        uses: quartx-analytics/ghcr-cleaner@registry_api
+        with:
+            token: ${{ secrets.PAT_TOKEN }}
+            repository_owner: ${{ github.repository_owner }}
+            repository: ${{ github.repository }}
+            package_name: eturnal
+            untagged_only: true
+            owner_type: ${{ env.OWNER_TYPE }}
+            except_untagged_multiplatform: true


### PR DESCRIPTION
This action needs a personal access token with 'delete:package' capacity defined as a secret for this repository. Secret name is PAT_TOKEN .

This will delete all test/ edge container images. It does not delete the released images.