### PR TITLE
fix: check static credentials before shared secret for numeric usernames

### DIFF
--- a/src/eturnal.erl
+++ b/src/eturnal.erl
@@ -140,15 +140,15 @@ handle_call({set_loglevel, Level}, _From, State) ->
         {reply, Err, State}
     end;
 handle_call({get_password, Username}, _From, State) ->
-    case {get_opt(secret), is_dynamic_username(Username)} of
-        {[Secret | _Secrets], true} ->
-            Password = derive_password(Username, [Secret]),
+    case lookup_static_password(Username) of
+        {ok, Password} ->
             {reply, {ok, Password}, State};
-        {_, _} ->
-            case maps:get(Username, get_opt(credentials), undefined) of
-                Password when is_binary(Password) ->
+        error ->
+            case {get_opt(secret), is_dynamic_username(Username)} of
+                {[Secret | _Secrets], true} ->
+                    Password = derive_password(Username, [Secret]),
                     {reply, {ok, Password}, State};
-                undefined ->
+                {_, _} ->
                     {reply, {error, no_credentials}, State}
             end
     end;
@@ -237,6 +237,16 @@ run_hook(Event, Info) ->
 -spec get_password(binary(), binary())
       -> binary() | [binary()] | {expired, binary() | [binary()]}.
 get_password(Username, _Realm) ->
+    case lookup_static_password(Username) of
+        {ok, Password} ->
+            ?LOG_DEBUG("Found static password for: ~ts", [Username]),
+            Password;
+        error ->
+            get_dynamic_password(Username)
+    end.
+
+-spec get_dynamic_password(binary()) -> binary() | [binary()] | {expired, binary() | [binary()]}.
+get_dynamic_password(Username) ->
     [Expiration | _Suffix] = binary:split(Username, <<$:>>),
     try binary_to_integer(Expiration) of
         ExpireTime ->
@@ -256,14 +266,8 @@ get_password(Username, _Realm) ->
                     end
             end
     catch _:badarg ->
-            ?LOG_DEBUG("Looking up password for: ~ts", [Username]),
-            case maps:get(Username, get_opt(credentials), undefined) of
-                Password when is_binary(Password) ->
-                    Password;
-                undefined ->
-                    ?LOG_INFO("Have no password for: ~ts", [Username]),
-                    <<>>
-            end
+            ?LOG_INFO("Have no password for: ~ts", [Username]),
+            <<>>
     end.
 
 %% API: retrieve option value.
@@ -313,6 +317,15 @@ reload_config() ->
     ok = gen_server:cast(?MODULE, reload).
 
 %% Internal functions: authentication.
+
+-spec lookup_static_password(binary()) -> {ok, binary()} | error.
+lookup_static_password(Username) ->
+    case maps:get(Username, get_opt(credentials), undefined) of
+        Password when is_binary(Password) ->
+            {ok, Password};
+        undefined ->
+            error
+    end.
 
 -spec is_dynamic_username(binary()) -> boolean().
 is_dynamic_username(Username) ->

--- a/test/eturnal_SUITE.erl
+++ b/test/eturnal_SUITE.erl
@@ -185,7 +185,9 @@ check_credentials(_Config) ->
     ct:pal("Checking invalid suffix"),
     {error, _Reason} = eturnal_ctl:get_credentials(Username, invalid),
     ct:pal("Checking static credentials"),
-    {ok, "l0vesBob"} = eturnal_ctl:get_password("alice").
+    {ok, "l0vesBob"} = eturnal_ctl:get_password("alice"),
+    ct:pal("Checking numeric static credentials"),
+    {ok, "numericPass"} = eturnal_ctl:get_password("00002063954332").
 
 -spec check_loglevel(config()) -> any().
 check_loglevel(_Config) ->
@@ -244,10 +246,13 @@ turn_udp(Config) ->
     Password1 = <<"l0vesBob">>,
     Username2 = <<"2145913200">>,
     Password2 = <<"cLwpKS2/9bWHf+agUImD47PIXNE=">>,
+    Username3 = <<"00002063954332">>,
+    Password3 = <<"numericPass">>,
     Realm = <<"eturnal.net">>,
     ct:pal("Allocating TURN relay on 127.0.0.1:~B (UDP)", [Port]),
     ok = stun_test:allocate_udp(Addr, Port, Username1, Realm, Password1),
-    ok = stun_test:allocate_udp(Addr, Port, Username2, Realm, Password2).
+    ok = stun_test:allocate_udp(Addr, Port, Username2, Realm, Password2),
+    ok = stun_test:allocate_udp(Addr, Port, Username3, Realm, Password3).
 
 -spec stun_udp(config()) -> any().
 stun_udp(Config) ->

--- a/test/eturnal_SUITE_data/eturnal-new-otp.yml
+++ b/test/eturnal_SUITE_data/eturnal-new-otp.yml
@@ -23,6 +23,7 @@ eturnal:
   secret: "crypt1c"
   credentials:
     alice: l0vesBob
+    "00002063954332": numericPass
   log_level: debug
   tls_options:
     - no_tlsv1

--- a/test/eturnal_SUITE_data/eturnal-old-otp.yml
+++ b/test/eturnal_SUITE_data/eturnal-old-otp.yml
@@ -18,6 +18,7 @@ eturnal:
   secret: "crypt1c"
   credentials:
     alice: l0vesBob
+    "00002063954332": numericPass
   log_level: debug
   tls_options:
     - no_tlsv1


### PR DESCRIPTION
## Problem

When a numeric username was configured as a static credential, eturnal
would incorrectly treat it as a TURN REST API (shared secret) username
instead of looking it up in the `credentials` map.

This happened because the authentication logic checked first whether the
username looked like a dynamic TURN REST timestamp (i.e. numeric), and
only fell back to static credentials when it did not. As a result, a
configuration like:

    credentials:
      "00002063954332": somePassword

would never match the static credential; eturnal would attempt to derive
a password from the shared secret instead.

## Fix

Introduce a `lookup_static_password/1` helper that checks the
`credentials` map for an exact username match. Both authentication paths
now consult static credentials first:

1. If the username is found in `credentials`, return the static password.
2. Otherwise, if the username looks like a TURN REST timestamp and a
   `secret` is configured, derive the password dynamically.
3. Otherwise, reject the request.

This preserves the shared secret optimization while giving explicitly
configured static credentials priority, regardless of whether their
username is numeric or not.

## Changes

- `src/eturnal.erl`: add `lookup_static_password/1`; update
  `handle_call({get_password, ...})` and `get_password/2` to check
  static credentials first; extract dynamic logic into
  `get_dynamic_password/1`
- `test/eturnal_SUITE_data/eturnal-new-otp.yml`,
  `test/eturnal_SUITE_data/eturnal-old-otp.yml`: add a numeric static
  credential entry for testing
- `test/eturnal_SUITE.erl`: add assertions for numeric static credential
  lookup and TURN allocation